### PR TITLE
Fix mmap use for non-purecap targets.

### DIFF
--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Arm Ltd. All rights reserved.
+ * Copyright (C) 2019-2020,2022 Arm Ltd. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,18 +47,11 @@ void ContinuousArenaMalloc::initialize(void) {
     s_Mutex = new Mutex();
 
     void *area_start = mmap(NULL, k_AreaSize,
-                            PROT_READ | PROT_WRITE,
-                            MAP_ANON | MAP_PRIVATE | MAP_ALIGNED(k_LgAreaSize),
+                            PROT_NONE | PROT_MAX(PROT_READ | PROT_WRITE),
+                            MAP_GUARD | MAP_ALIGNED(k_LgAreaSize),
                             -1, 0);
 
     ASSERT(area_start != MAP_FAILED);
-
-    void *area_start_remapped = mmap(area_start, k_AreaSize,
-                                     PROT_NONE,
-                                     MAP_GUARD | MAP_FIXED,
-                                     -1, 0);
-
-    ASSERT(area_start == area_start_remapped);
 
     LOG_CHERI("initialize() - reserved %zu bytes starting from %p\n",
               k_AreaSize, area_start);


### PR DESCRIPTION
On both hybrid and AArch64 targets, a MAP_GUARD mapping overlapping an existing one fails on CheriBSD. This appears to be a bug, but we only need a single mapping here anyway so this workaround is an improvement in its own right.