### PR TITLE
Fix ContinuousArenaMalloc

### DIFF
--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -66,14 +66,14 @@ void ContinuousArenaMalloc::initialize(void) {
      * before the initialization is finished,
      * during the arenas.create operation */
     s_extentHooks.alloc = extentAlloc;
-    s_extentHooks.dalloc = extentDalloc;
+    s_extentHooks.dalloc = NULL;  // Opt out.
     s_extentHooks.destroy = extentDestroy;
-    s_extentHooks.commit = extentCommit;
-    s_extentHooks.decommit = extentDecommit;
+    s_extentHooks.commit = NULL;  // Opt out.
+    s_extentHooks.decommit = NULL;  // Opt out.
     s_extentHooks.purge_lazy = extentPurgeLazy;
     s_extentHooks.purge_forced = extentPurgeForced;
-    s_extentHooks.split = extentSplit;
-    s_extentHooks.merge = extentMerge;
+    s_extentHooks.split = NULL;  // Opt out.
+    s_extentHooks.merge = NULL;  // Opt out.
 
     extent_hooks_t *newHooksPtr = &s_extentHooks;
     size_t indexSize = sizeof(s_arenaIndex);
@@ -110,13 +110,13 @@ void *ContinuousArenaMalloc::internalAllocateAligned(size_t alignment,
     return mallocx(size, MALLOCX_ALIGN(alignment) | MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
 }
 
-void* ContinuousArenaMalloc::internalReallocate(void* ptr, size_t size)
+void *ContinuousArenaMalloc::internalReallocate(void *ptr, size_t size)
 {
     ASSERT(s_Initialized);
     return rallocx(ptr, size, MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
 }
 
-void ContinuousArenaMalloc::internalFree(void* ptr)
+void ContinuousArenaMalloc::internalFree(void *ptr)
 {
     ASSERT(s_Initialized);
     dallocx(ptr, MALLOCX_TCACHE_NONE);
@@ -162,7 +162,7 @@ bool ContinuousArenaMalloc::isAvailableRange(void *addr, size_t size)
     return isValidRange(addr, size) && (reinterpret_cast<char *>(addr) >= s_Current);
 }
 
-void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
+void *ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
                                          void *new_addr,
                                          size_t size,
                                          size_t alignment,
@@ -218,26 +218,6 @@ void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
     return ret;
 }
 
-bool ContinuousArenaMalloc::extentDalloc(extent_hooks_t *extent_hooks,
-                                         void *addr,
-                                         size_t size,
-                                         bool committed,
-                                         unsigned arena_ind)
-{
-    MutexLocker locker(s_Mutex);
-
-    LOG_CHERI("dalloc(%p, %p, %zu, %c, %u)\n",
-              extent_hooks,
-              addr,
-              size,
-              committed ? 'T' : 'F',
-              arena_ind);
-    ASSERT(isAllocatedRange(addr, size));
-
-    // opt-out from deallocation; jemalloc should re-use the area
-    return true;
-}
-
 void ContinuousArenaMalloc::extentDestroy(extent_hooks_t *extent_hooks,
                                           void *addr,
                                           size_t size,
@@ -260,50 +240,34 @@ void ContinuousArenaMalloc::extentDestroy(extent_hooks_t *extent_hooks,
     ASSERT(ret == addr);
 }
 
-bool ContinuousArenaMalloc::extentCommit(extent_hooks_t *extent_hooks,
-                                         void *addr,
-                                         size_t size,
-                                         size_t offset,
-                                         size_t length,
-                                         unsigned arena_ind)
+bool ContinuousArenaMalloc::extentPurgeCommon(extent_hooks_t *extent_hooks,
+                                              void *addr,
+                                              size_t size,
+                                              size_t offset,
+                                              size_t length,
+                                              unsigned arena_ind)
 {
-    MutexLocker locker(s_Mutex);
+    UNUSED_PARAM(extent_hooks);
+    UNUSED_PARAM(arena_ind);
 
-    LOG_CHERI("commit(%p, %p, %zu, %zu, %zu, %u)\n",
-              extent_hooks,
-              addr,
-              size,
-              offset,
-              length,
-              arena_ind);
-
-    // this function should never be called, since we always return committed memory and
-    // opt-out from decommit
-
-    ASSERT_NOT_REACHED();
-}
-
-bool ContinuousArenaMalloc::extentDecommit(extent_hooks_t *extent_hooks,
-                                           void *addr,
-                                           size_t size,
-                                           size_t offset,
-                                           size_t length,
-                                           unsigned arena_ind)
-{
-    MutexLocker locker(s_Mutex);
-
-    LOG_CHERI("decommit(%p, %p, %zu, %zu, %zu, %u)\n",
-              extent_hooks,
-              addr,
-              size,
-              offset,
-              length,
-              arena_ind);
+    ASSERT(s_Mutex->tryLock() == false);
 
     ASSERT(isAllocatedRange(addr, size));
 
-    // opt-out from decommit
-    return true;
+    char *start = reinterpret_cast<char *>(addr) + offset;
+    ASSERT(start >= reinterpret_cast<char *>(addr));
+    ASSERT((start + length) <= (reinterpret_cast<char *>(addr) + size));
+    ASSERT(isAllocatedRange(start, length));
+
+    void *ret = mmap(start,
+                     length,
+                     PROT_READ | PROT_WRITE,
+                     MAP_ANON | MAP_PRIVATE | MAP_FIXED,
+                     -1, 0);
+
+    ASSERT(ret == start);
+
+    return false;
 }
 
 bool ContinuousArenaMalloc::extentPurgeLazy(extent_hooks_t *extent_hooks,
@@ -323,22 +287,8 @@ bool ContinuousArenaMalloc::extentPurgeLazy(extent_hooks_t *extent_hooks,
               length,
               arena_ind);
 
-    ASSERT(isAllocatedRange(addr, size));
-
-    char *start = reinterpret_cast<char *>(addr) + offset;
-    ASSERT(start >= reinterpret_cast<char *>(addr));
-    ASSERT((start + length) <= (reinterpret_cast<char *>(addr) + size));
-    ASSERT(isAllocatedRange(start, length));
-
-    void *ret = mmap(start,
-                     length,
-                     PROT_READ | PROT_WRITE,
-                     MAP_ANON | MAP_PRIVATE | MAP_FIXED,
-                     -1, 0);
-
-    ASSERT(ret == start);
-
-    return false;
+    // For simplicity, just force all purges.
+    return extentPurgeCommon(extent_hooks, addr, size, offset, length, arena_ind);
 }
 
 bool ContinuousArenaMalloc::extentPurgeForced(extent_hooks_t *extent_hooks,
@@ -358,73 +308,7 @@ bool ContinuousArenaMalloc::extentPurgeForced(extent_hooks_t *extent_hooks,
               length,
               arena_ind);
 
-    ASSERT(isAllocatedRange(addr, size));
-
-    char *start = reinterpret_cast<char *>(addr) + offset;
-    ASSERT(start >= reinterpret_cast<char *>(addr));
-    ASSERT((start + length) <= (reinterpret_cast<char *>(addr) + size));
-    ASSERT(isAllocatedRange(start, length));
-
-    void *ret = mmap(start,
-                     length,
-                     PROT_READ | PROT_WRITE,
-                     MAP_ANON | MAP_PRIVATE | MAP_FIXED,
-                     -1, 0);
-
-    ASSERT(ret == start);
-
-    return false;
-}
-
-bool ContinuousArenaMalloc::extentSplit(extent_hooks_t *extent_hooks,
-                                        void *addr,
-                                        size_t size,
-                                        size_t size_a,
-                                        size_t size_b,
-                                        bool committed,
-                                        unsigned arena_ind)
-{
-    MutexLocker locker(s_Mutex);
-
-    LOG_CHERI("split(%p, %p, %zu, %zu, %zu, %c, %u)\n",
-              extent_hooks,
-              addr,
-              size,
-              size_a,
-              size_b,
-              committed ? 'T' : 'F',
-              arena_ind);
-
-    ASSERT(isAllocatedRange(addr, size));
-
-    // opt-out from splitting
-    return true;
-}
-
-bool ContinuousArenaMalloc::extentMerge(extent_hooks_t *extent_hooks,
-                                        void *addr_a,
-                                        size_t size_a,
-                                        void *addr_b,
-                                        size_t size_b,
-                                        bool committed,
-                                        unsigned arena_ind)
-{
-    MutexLocker locker(s_Mutex);
-
-    LOG_CHERI("merge(%p, %p, %zu, %p, %zu, %c, %u)\n",
-              extent_hooks,
-              addr_a,
-              size_a,
-              addr_b,
-              size_b,
-              committed ? 'T' : 'F',
-              arena_ind);
-
-    ASSERT(isAllocatedRange(addr_a, size_a));
-    ASSERT(isAllocatedRange(addr_b, size_b));
-
-    // opt-out from merging
-    return true;
+    return extentPurgeCommon(extent_hooks, addr, size, offset, length, arena_ind);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020,2022 Arm Ltd. All rights reserved.
+ * Copyright (C) 2019-2022 Arm Ltd. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -161,12 +161,12 @@ void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
     if (new_addr != NULL || size == 0) {
         ret = NULL;
     } else {
-        s_Current = __builtin_align_up(s_Current, alignment);
+        char *start = __builtin_align_up(s_Current, alignment);
 
-        if (!isValidRange(s_Current, size)) {
+        if (!isValidRange(start, size)) {
             ret = NULL;
         } else {
-            ret = mmap(s_Current,
+            ret = mmap(start,
                        size,
                        PROT_READ | PROT_WRITE,
                        MAP_ANON | MAP_PRIVATE | MAP_FIXED,
@@ -176,13 +176,13 @@ void* ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
                 ret = NULL;
             } else {
 #ifdef __CHERI_PURE_CAPABILITY__
-                ASSERT(__builtin_cheri_address_get(ret) == __builtin_cheri_address_get(s_Current));
+                ASSERT(__builtin_cheri_address_get(ret) == __builtin_cheri_address_get(start));
 #endif
 
                 *zero = true;
                 *commit = true;
 
-                s_Current += size;
+                s_Current = start + size;
             }
         }
     }

--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -27,6 +27,7 @@
 #include <wtf/ContinuousArenaMalloc.h>
 
 #include <sys/mman.h>
+#include <cheriintrin.h>
 
 #if USE(CONTINUOUS_ARENA)
 
@@ -186,14 +187,25 @@ void *ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
     if (new_addr != NULL || size == 0) {
         ret = NULL;
     } else {
-        char *start = __builtin_align_up(s_Current, alignment);
+        // The masks have all bits set except for zero or more low-order bits,
+        // such that `& mask` aligns down to a multiple of a power of two.
+        ASSERT(hasOneBitSet(alignment));
+        size_t align_mask = -alignment;
+        size_t repr_mask = cheri_representable_alignment_mask(size);
+        size_t repr_size = cheri_representable_length(size);
 
-        // TODO: Pass `size` through round_representable_length.
-        if (!isAvailableRange(start, size)) {
-            ret = NULL;
-        } else {
+        ASSERT(hasZeroOrOneBitsSet(~repr_mask + 1));
+        ASSERT(repr_size >= size);
+
+        // We need to align up, not down, so we don't hand out memory that's
+        // already allocated.
+        size_t mask = align_mask & repr_mask;
+        size_t start_addr = (cheri_address_get(s_Current) + ~mask) & mask;
+        void *start = cheri_address_set(s_Current, start_addr);
+
+        if (isAvailableRange(start, repr_size)) {
             ret = mmap(start,
-                       size,
+                       repr_size,
                        PROT_READ | PROT_WRITE,
                        MAP_ANON | MAP_PRIVATE | MAP_FIXED,
                        -1, 0);
@@ -202,14 +214,18 @@ void *ContinuousArenaMalloc::extentAlloc(extent_hooks_t *extent_hooks,
                 ret = NULL;
             } else {
 #ifdef __CHERI_PURE_CAPABILITY__
-                ASSERT(__builtin_cheri_address_get(ret) == __builtin_cheri_address_get(start));
+                // We checked representability, so this should be exact.
+                ASSERT(cheri_address_get(ret) == cheri_address_get(start));
+                ASSERT(cheri_length_get(ret) == repr_size);
 #endif
 
                 *zero = true;
                 *commit = true;
 
-                s_Current = start + size;
+                s_Current = reinterpret_cast<char *>(start) + cheri_length_get(ret);
             }
+        } else {
+            ret = NULL;
         }
     }
 

--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -268,11 +268,10 @@ bool ContinuousArenaMalloc::extentPurgeCommon(extent_hooks_t *extent_hooks,
 
     ASSERT(s_Mutex->tryLock() == false);
 
+    ASSERT(offset <= size);
+    ASSERT((offset + length) <= size);
     ASSERT(isAllocatedRange(addr, size));
-
     char *start = reinterpret_cast<char *>(addr) + offset;
-    ASSERT(start >= reinterpret_cast<char *>(addr));
-    ASSERT((start + length) <= (reinterpret_cast<char *>(addr) + size));
     ASSERT(isAllocatedRange(start, length));
 
     void *ret = mmap(start,

--- a/Source/WTF/wtf/ContinuousArenaMalloc.h
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.h
@@ -145,28 +145,17 @@ private:
                              bool *zero,
                              bool *commit,
                              unsigned arena_ind);
-    static bool extentDalloc(extent_hooks_t *extent_hooks,
-                             void *addr,
-                             size_t size,
-                             bool committed,
-                             unsigned arena_ind);
     static void extentDestroy(extent_hooks_t *extent_hooks,
                               void *addr,
                               size_t size,
                               bool committed,
                               unsigned arena_ind);
-    static bool extentCommit(extent_hooks_t *extent_hooks,
-                             void *addr,
-                             size_t size,
-                             size_t offset,
-                             size_t length,
-                             unsigned arena_ind);
-    static bool extentDecommit(extent_hooks_t *extent_hooks,
-                               void *addr,
-                               size_t size,
-                               size_t offset,
-                               size_t length,
-                               unsigned arena_ind);
+    static bool extentPurgeCommon(extent_hooks_t *extent_hooks,
+                                  void *addr,
+                                  size_t size,
+                                  size_t offset,
+                                  size_t length,
+                                  unsigned arena_ind);
     static bool extentPurgeLazy(extent_hooks_t *extent_hooks,
                                 void *addr,
                                 size_t size,
@@ -179,20 +168,6 @@ private:
                                   size_t offset,
                                   size_t length,
                                   unsigned arena_ind);
-    static bool extentSplit(extent_hooks_t *extent_hooks,
-                            void *addr,
-                            size_t size,
-                            size_t size_a,
-                            size_t size_b,
-                            bool committed,
-                            unsigned arena_ind);
-    static bool extentMerge(extent_hooks_t *extent_hooks,
-                            void *addr_a,
-                            size_t size_a,
-                            void *addr_b,
-                            size_t size_b,
-                            bool committed,
-                            unsigned arena_ind);
 
     static bool s_Initialized;
     static unsigned int s_arenaIndex;

--- a/Source/WTF/wtf/ContinuousArenaMalloc.h
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019-2020 Arm Ltd. All rights reserved.
+ *  Copyright (C) 2019-2021 Arm Ltd. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -131,7 +131,13 @@ private:
     static void* internalReallocate(void *p, size_t size);
     static void internalFree(void* ptr);
 
+    // True iff [addr, addr+size) is a subset of or equal to [s_Start, s_End).
     static bool isValidRange(void *addr, size_t size);
+    // True iff [addr, addr+size) is a subset of or equal to [s_Start, s_Current).
+    static bool isAllocatedRange(void *addr, size_t size);
+    // True iff [addr, addr+size) is a subset of or equal to [s_Current, s_End).
+    static bool isAvailableRange(void *addr, size_t size);
+
     static void* extentAlloc(extent_hooks_t *extent_hooks,
                              void *new_addr,
                              size_t size,


### PR DESCRIPTION
Fix a couple of minor bugs in `ContinuousArenaMalloc`, and clean up a bit at the same time. Notably:

- Make `isValidRange` respect its inputs.
- Ensure that extent allocation requests unrepresentable by a capability are properly handled.

