### PR TITLE
Fix an operator precedence bug.

### DIFF
--- a/Source/WTF/wtf/WordLock.cpp
+++ b/Source/WTF/wtf/WordLock.cpp
@@ -143,7 +143,7 @@ NEVER_INLINE void WordLock::lockSlow()
             ASSERT(currentWordValue & isQueueLockedBit);
             ASSERT(currentWordValue & isLockedBit);
             uintptr_t newWordValue = bitwise_cast<uintptr_t>(queueHead);
-            COMPILE_ASSERT(isLockedBit | isQueueLockedBit == queueHeadMask, "");
+            COMPILE_ASSERT((isLockedBit | isQueueLockedBit) == queueHeadMask, "");
             ASSERT(Pointer::getLowBits<queueHeadMask>(newWordValue) == 0);
             newWordValue = Pointer::setLowBits(newWordValue, isLockedBit);
             m_word.store(newWordValue);
@@ -237,7 +237,7 @@ NEVER_INLINE void WordLock::unlockSlow()
     ASSERT(currentWordValue & isQueueLockedBit);
     ASSERT((currentWordValue & ~queueHeadMask) == bitwise_cast<uintptr_t>(queueHead));
     uintptr_t newWordValue = bitwise_cast<uintptr_t>(newQueueHead);
-    COMPILE_ASSERT(isLockedBit | isQueueLockedBit == queueHeadMask, "");
+    COMPILE_ASSERT((isLockedBit | isQueueLockedBit) == queueHeadMask, "");
     ASSERT(Pointer::getLowBits<queueHeadMask>(newWordValue) == 0);
     m_word.store(newWordValue);
 


### PR DESCRIPTION
This was broken in #4 ([here](https://github.com/capablevms/webkit/pull/4/files#diff-98598ddc60a86ec9f9c11b5959e6a9dd5213dc8b39b4e3a48c03533f83e50906R240)). The compiler warned about it, but it was lost amongst the other warnings.