### PR TITLE
Minor buildbot fixes.

### DIFF
--- a/.buildbot-test.sh
+++ b/.buildbot-test.sh
@@ -29,9 +29,10 @@ for build in $(ls -r builds/); do
     echo "==== $ss on $build ===="
     while read name; do
       js="$ss/$name.js"
-      lib_path="builds/$build${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-      echo "Running: LD_LIBRARY_PATH=\"$lib_path\" \"builds/$build/bin/jsc\" \"$js\""
-      if LD_LIBRARY_PATH="$lib_path" "builds/$build/bin/jsc" "$js"; then
+      # Recent cheribuilds produce jsc binaries with RUNPATH set, so we don't
+      # need to specify the library path.
+      echo "Running: \"builds/$build/bin/jsc\" \"$js\""
+      if "builds/$build/bin/jsc" "$js"; then
         echo "  - PASS" >&2
       else
         failures="${failures}  - $build: $ss/$name\n"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -9,6 +9,7 @@ set -eu
 CHERI_DIR="${CHERI_DIR-$HOME/cheri/output}"
 CHERIBUILD_DIR="${CHERIBUILD_DIR-$HOME/cheri-build}"
 WEBKIT_DIR="${REPO_DIR-$PWD}"
+cd "$WEBKIT_DIR"
 
 CHERI_RO_DIR="$(dirname "$CHERI_DIR")"  # E.g. ~/cheri
 
@@ -44,7 +45,9 @@ echo "Symlinking WebKit test subject into the CHERI root: $CHERI_RW_DIR/webkit -
 ln -fsT "$WEBKIT_DIR" "$CHERI_RW_DIR/webkit"
 
 # It's useful to see (roughly) what was copied in CI logs.
+echo "---- $CHERI_RW_DIR ----"
 ls -l "$CHERI_RW_DIR"
+echo "---- $CHERI_RW_DIR/output ----"
 ls -l "$CHERI_RW_DIR/output"
 
 TARGET_FILES_DIR="$BUILDBOT_SCRATCH_DIR/target_files"


### PR DESCRIPTION
I fixed these whilst working on the hybrid-build PR (which will follow), but these are simple changes and don't really belong with that.

The `.buildbot.sh` subdirectory fix is perhaps the most useful command here. I've been working in `Source/JavaScriptCore`, and testing with a command like this:

```
CHERIBUILD_DIR=~/work/cheribuild REPO_DIR=$(realpath ../..) ../../.buildbot.sh
```

