### PR TITLE
CHERI: Fix non-purecap builds.

### DIFF
--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -32,6 +32,10 @@
 #include <wtf/text/UniquedStringImpl.h>
 #include <wtf/text/WTFString.h>
 
+#if __has_feature(capabilities)
+#include <cheriintrin.h>
+#endif
+
 namespace WTF {
 
 PrintStream::PrintStream() { }
@@ -179,8 +183,6 @@ void printInternal(PrintStream& out, double value)
 #if __has_feature(capabilities)
 void printInternal(PrintStream& out, __uintcap_t value)
 {
-    int tag = __builtin_cheri_tag_get((const void *) value);
-
     uint64_t* value_u64_p = reinterpret_cast<uint64_t *>(&value);
 
 #if CPU(LITTLE_ENDIAN)
@@ -191,10 +193,10 @@ void printInternal(PrintStream& out, __uintcap_t value)
     uint64_t low64 = value_u64_p[1];
 #endif
 
-    ASSERT(low64 == __builtin_cheri_address_get((const void *) value));
+    ASSERT(low64 == cheri_address_get(value));
 
     out.printf("0x%c:%016lx:%016lx",
-               tag ? '1' : '0',
+               cheri_tag_get(value) ? '1' : '0',
                high64,
                low64);
 }


### PR DESCRIPTION
This fixes both the `morello-webkit-aarch64` and the `morello-webkit-morello-hybrid` targets, and also enables hybrid tests in CI.