### PR TITLE
Check for mallocx alignment behaviour.

### DIFF
--- a/.buildbot-test.sh
+++ b/.buildbot-test.sh
@@ -26,6 +26,9 @@ du -hs *
 echo "$PWD/builds:"
 du -hs builds/*
 
+echo "Disabling revocation to work around https://github.com/CTSRD-CHERI/cheribsd/issues/1964"
+sysctl security.cheri.runtime_revocation_default=0
+
 failures=''
 # Run higher tiers first (ls -r). They are most complicated, most likely to
 # receive development, and run a lot faster than lower tiers.

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -145,7 +145,9 @@ build() {
   popd
 }
 
-build morello-purecap --morello-webkit/build-type Debug --morello-webkit/backend cloop
+# TODO: 'cloop' is disabled because it's slow, and takes longer than the Merge
+# Queues timeout. We should reinstate it, perhaps as a weekly run or similar.
+#build morello-purecap --morello-webkit/build-type Debug --morello-webkit/backend cloop
 build morello-purecap --morello-webkit/build-type Debug --morello-webkit/backend tier1asm
 # TODO: tier2asm shows intermittent failures, which are currently under
 # investigation. To avoid CI disruption, it is disabled here for now, but

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,0 +1,9 @@
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true

--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -50,6 +50,12 @@ void ContinuousArenaMalloc::initialize(void) {
 
     s_Mutex = new Mutex();
 
+#if __has_feature(capabilities)
+    // CheriBSD revocation does not support MALLOCX_ARENA.
+    // See: https://man.cheribsd.org/cgi-bin/man.cgi/mrs
+    ASSERT(!malloc_is_revoking());
+#endif
+
     void *area_start = mmap(NULL, k_AreaSize,
                             PROT_NONE | PROT_MAX(PROT_READ | PROT_WRITE),
                             MAP_GUARD | MAP_ALIGNED(k_LgAreaSize),

--- a/Source/WTF/wtf/ContinuousArenaMalloc.cpp
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.cpp
@@ -111,13 +111,25 @@ void *ContinuousArenaMalloc::internalAllocateAligned(size_t alignment,
     ASSERT((alignment & (alignment - 1)) == 0);
     ASSERT(s_Initialized);
 
-    return mallocx(size, MALLOCX_ALIGN(alignment) | MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
+    void * result = mallocx(size, MALLOCX_ALIGN(alignment) | MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
+#if __has_feature(capabilities)
+    // If this happens, try disabling capability revocation.
+    // See: https://github.com/CTSRD-CHERI/cheribsd/issues/1964
+    ASSERT(cheri_is_aligned(result, alignment));
+#endif
+    return result;
 }
 
 void *ContinuousArenaMalloc::internalReallocate(void *ptr, size_t size)
 {
     ASSERT(s_Initialized);
-    return rallocx(ptr, size, MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
+    void * result = rallocx(ptr, size, MALLOCX_TCACHE_NONE | MALLOCX_ARENA(s_arenaIndex));
+#if __has_feature(capabilities)
+    // If this happens, try disabling capability revocation.
+    // See: https://github.com/CTSRD-CHERI/cheribsd/issues/1964
+    ASSERT(cheri_is_aligned(result, size));
+#endif
+    return result;
 }
 
 void ContinuousArenaMalloc::internalFree(void *ptr)

--- a/Source/WTF/wtf/ContinuousArenaMalloc.h
+++ b/Source/WTF/wtf/ContinuousArenaMalloc.h
@@ -46,7 +46,7 @@ public:
     }
 
     static void* realloc(void* p, size_t size) {
-        void *ret = internalReallocate(p, size);
+        void *ret = tryRealloc(p, size);
 
         if (!ret) {
             CRASH();
@@ -72,7 +72,7 @@ public:
     }
 
     static void* tryRealloc(void* p, size_t size) {
-        return internalReallocate(p, size);
+        return internalReallocateAligned(p, sizeof(void *), size);
     }
 
     static bool isWithin(size_t non_cap_ptr) {
@@ -128,7 +128,7 @@ private:
 #endif
 
     static void* internalAllocateAligned(size_t alignment, size_t size);
-    static void* internalReallocate(void *p, size_t size);
+    static void* internalReallocateAligned(void *p, size_t alignment, size_t size);
     static void internalFree(void* ptr);
 
     // True iff [addr, addr+size) is a subset of or equal to [s_Start, s_End).

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = ["buildbot/ci-builder"]
-delete_merged_branches = true
-cut_body_after = ""
-# A full run should complete within 12 hours, but we might add other
-# configurations to it later, so add a little leeway.
-timeout_sec = 86400 # 24 hours


### PR DESCRIPTION
CheriBSD's revocation support is incompatible with `MALLOCX_ALIGN` and `MALLOCX_ARENA`, so disable it in tests, and also add assertions to `ContinuousArenaMalloc` to ensure that we're actually getting aligned capabilities in the expected memory region.

This PR also adds CapableVMs merge queues support.